### PR TITLE
Add --out option for specifying output location

### DIFF
--- a/scripts/argparser.py
+++ b/scripts/argparser.py
@@ -16,6 +16,8 @@ def cli_arg_parser():
     parser.add_argument("-p",
                         "--pack",
                         help="Available packers: bz2, gz, lzma")
+    parser.add_argument("-o", "--out",
+                        help="Destination for the output file")
     # Return to dictionary
     return vars(parser.parse_args())
 

--- a/scripts/obfuscator.py
+++ b/scripts/obfuscator.py
@@ -371,6 +371,7 @@ class Obfuscator:
 
     def _save_obfuscated_file(self):
             try:
+                path_for_output = "./" if not self.args["out"] else self.args["out"] + "/"
                 new_file_content = ''
                 # Shebang check & fix
                 for index, token in enumerate(self.tokenizer.TOKENS[:4]):
@@ -392,7 +393,7 @@ class Obfuscator:
                 # Pack
                 new_file_content = self._pack(new_file_content)
                 # Write file
-                write_file(new_file_name, new_file_content)
+                write_file(path_for_output + new_file_name, new_file_content)
             except Exception as ex:
                 self.logger.log(f'{type(ex).__name__} has occured while saving the obfuscated file', state='error')
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We can consider this as a quick fix. The reason behind this addition is, where ever we run the obfuscator, it was creating the file the path that it exists. With that, we can manipulate the output location.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
