### PR TITLE
Command line and args improvements

### DIFF
--- a/PyObfx.py
+++ b/PyObfx.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from scripts.argparser import cli_arg_parser
-from scripts.obfuscator import Obfuscator
 from scripts.banner import print_banner
+from scripts.obfuscator import Obfuscator
+
 
 def main():
     print_banner()
-    Obfuscator(cli_arg_parser()).obfuscate()
+    Obfuscator(**cli_arg_parser()).obfuscate()
+
 
 if __name__ == "__main__":
     main()

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ pip install -r requirements.txt
 
 In order to obfuscate a single file:
 ```
-python3 PyObfx.py -f <file_name>
+python3 PyObfx.py <file_name>
 ```
 
 To pack the file after obfuscation: (Available packers are bz2, gz and lzma)
 ```
-python3 PyObfx.py -f <file_name> -p <packer>
+python3 PyObfx.py <file_name> -p <packer>
 ```
 
 For other options, see:

--- a/scripts/argparser.py
+++ b/scripts/argparser.py
@@ -1,18 +1,41 @@
 #!/usr/bin/python3.6
 # -*- coding: utf-8 -*-
 import argparse
+import sys
+from typing import Dict, Any
 
-def cli_arg_parser():
+
+def cli_arg_parser() -> Dict[str, Any]:
     """
     Parses the arguments from CLI and returns to the dictionary
     where keys are the options/flags
 
     ex: when -f triggered, there'll be 'file' key in the dictionary.
     and values are accessible with list syntax `[]`
+
+    Test when file passed with -f keyword
+    >>> import sys
+    >>> sys.argv = [sys.argv[0], '-f', "file name"]
+    >>> cli_arg_parser()
+    {'file': 'file name', 'pack': None, 'silent': False, 'out': None, 'no_log': False, 'str_gen': None}
+
+    Test when filename passed as positional argument
+    >>> sys.argv = [sys.argv[0], "file name"]
+    >>> cli_arg_parser()
+    {'file': 'file name', 'pack': None, 'silent': False, 'out': None, 'no_log': False, 'str_gen': None}
+
+    Test no file passed
+    >>> sys.argv = [sys.argv[0], ]
+    >>> cli_arg_parser()
+    Traceback (most recent call last):
+      ...
+    SystemExit: 2
     """
     parser = argparse.ArgumentParser()
+    parser.add_argument("filename", nargs='?',
+                        help="File to be obfuscated. Optional")
     parser.add_argument("-f", "--file",
-                        help="File to be obfscated.", required=True)
+                        help="File to be obfuscated.", required=False)
     parser.add_argument("-p",
                         "--pack",
                         help="Available packers: bz2, gz, lzma")
@@ -28,5 +51,17 @@ def cli_arg_parser():
     parser.add_argument("--str-gen",
                         help="Available string generators: jp, ch, in")
     # Return to dictionary
-    return vars(parser.parse_args())
+    args = vars(parser.parse_args())
+    filename = args.pop('filename')
+    if filename:
+        args['file'] = filename
+    if not args['file']:
+        print("%s: error: the following arguments are required: -f/--file" % __file__, file=sys.stderr)
+        sys.exit(2)
+    return args
 
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/scripts/obfuscator.py
+++ b/scripts/obfuscator.py
@@ -10,7 +10,7 @@ from scripts.packer import *
 
 
 class Obfuscator:
-    def __init__(self, args):
+    def __init__(self, **args):
         # Logger
         self.logger = Log(log_name=f"pyobfx_log-{time.strftime('%X')}.txt", active=args['silent']) if not args['no_log'] else Log(active=args['silent'])
         self.logger.log('Starting obfuscator')


### PR DESCRIPTION
Added filename as a positional argument. No need to add `-f` keyword.

## Description
Added filename as a positional argument. No need to add `-f` keyword.
Backward compatibility kept.
`Obfuscator` constructor takes args as a standard python keyword argument.

## Motivation and Context
CLI usage becomes more convenient. As filename required anyway.

## How Has This Been Tested?
Added doctests to `argparser.py`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
