### PR TITLE
fix bugs：strings encrypt and for in  loop issues.

### DIFF
--- a/scripts/strgen.py
+++ b/scripts/strgen.py
@@ -7,7 +7,7 @@ py_keywords  = __import__('keyword').kwlist
 gen_alphabet = lambda x, y: ''.join(map(chr, range(x, y)))
 
 hindi    = gen_alphabet(0x900, 0x97F)   # Devanagari ( 0900 - 097F )
-chinese  = gen_alphabet(0x4E00, 0x9FFF) # CJK Unified Ideographs ( 4E00 - 9FFF )
+chinese  = gen_alphabet(0x4E00, 0x9FBF) # CJK Unified Ideographs ( 4E00 - 9FFF )
 japanese = gen_alphabet(0x3040, 0x309F) # Hiragana ( 3040 - 309F)
 
 random_types = {


### PR DESCRIPTION
Some strings are difficult to handle in the token, I filtered some strings according to the rules;
When the variable is confused, the for loop is modified during runtime, which leads to the subsequent logic problem of the for loop. New global variables are added for filtering, and those that have been processed are no longer processed